### PR TITLE
Auto-install of missing plugins

### DIFF
--- a/core/mrbuilder-optionsmanager/README.md
+++ b/core/mrbuilder-optionsmanager/README.md
@@ -55,6 +55,7 @@ const optionsManager = new OptionsManager({prefix:'whatever'});
  * warn - A function for logging warn level console.warn,
  * _require - A require function useful for scripts require,
  * aliasObj - Alias's you want to pass
+ * handleNotFound - Function to call when a package is not found.
 
 
 ## Resolution

--- a/core/mrbuilder-optionsmanager/package.json
+++ b/core/mrbuilder-optionsmanager/package.json
@@ -2,13 +2,15 @@
   "name": "mrbuilder-optionsmanager",
   "version": "1.0.0",
   "scripts": {
-    "test": "mocha test/**"
+    "test": "mocha test/**",
+    "env": "env"
   },
   "bin": {
     "mrbuilder-options-debug": "./bin/mrbuilder-options-debug.js"
   },
   "dependencies": {
-    "mrbuilder-utils": "^1.0.0"
+    "mrbuilder-utils": "^1.0.0",
+    "which": "^1.3.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/core/mrbuilder-optionsmanager/src/handleNotFoundTryInstall.js
+++ b/core/mrbuilder-optionsmanager/src/handleNotFoundTryInstall.js
@@ -1,0 +1,74 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+function findExecPath() {
+    return process.env['$npm_execpath'] || require('which')
+        .sync('yarn', { nothrow: true }) || require('which')
+               .sync('npm', { nothrow: true });
+
+}
+
+const yarnRe = /.*[/]?yarn([.]js)?$/;
+
+/**
+ * Tries to install a package as dev dependency.
+ * @param e
+ * @param pkg
+ * @param isDev - set to false if it is not a dev dependency.
+ */
+
+module.exports =
+    function handleNotFoundTryInstall(e, pkg, isDev = true) {
+        const warn = this.warn || console.warn;
+        const info = this.info || console.log;
+
+        const npmPath = findExecPath();
+        if (npmPath) {
+            info(
+                `using yarn '${npmPath}' to install '${pkg}' this might take a minute.`);
+
+            const isYarn = yarnRe.test(npmPath);
+            const args   = isYarn ? ['add', pkg] : ['install', pkg];
+
+            if (isDev) {
+                args.push(isYarn ? '-D' : '--save-dev');
+            }
+
+            const res = spawnSync(npmPath, args);
+
+            if (res.status === 0) {
+                info(`install of '${pkg}' succeeded.`);
+                return;
+            }
+            const err = res.stderr + '';
+            warn(`install of '${pkg}' failed!
+            
+             try running
+
+            $ yarn add ${pkg} ${isDev ? '-D' : ''}
+
+            or npm
+
+            $ npm install ${pkg} ${isDev ? '--save-dev' : ''}
+            
+            
+            \n ` + err);
+            throw (e || err);
+
+        } else {
+            warn(
+                `could not find yarn or npm to install '${pkg}' 
+            Try adding a command to your package.json 
+            {
+              ...
+              "scripts":{
+                 "${path.basename(process.env.argv[1])}":"${process.env.argv[1]}"
+              }  
+            }
+            $ yarn run mrbuilder
+            
+            or adding the path to yarn to PATH .
+            run under package.json scripts for better results.`);
+            throw e;
+        }
+
+    };

--- a/core/mrbuilder-optionsmanager/test/OptionsManager-test.js
+++ b/core/mrbuilder-optionsmanager/test/OptionsManager-test.js
@@ -59,6 +59,10 @@ describe('mrbuilder-optionsmanager', function () {
                 prefix  : 'tester',
                 cwd     : cwd(name),
                 _require: require,
+                handleNotFound(e, pkg){
+                    console.log(e, pkg);
+                    throw e;
+                }
             }, config)), config);
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6345,6 +6345,10 @@ nomnom@~1.6.2:
     colors "0.5.x"
     underscore "~1.4.4"
 
+noop@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/noop/-/noop-0.2.2.tgz#868b86cd3a26af8c7d4788d3fe923d586870909b"
+
 "nopt@2 || 3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -9701,7 +9705,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.1, which@^1.2.14, which@^1.2.9:
+which@1, which@^1.2.1, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
The idea is if a plugin is defined but not in the package.json the optionsmanager will attempt add the plugin to the devDependencies of the top level component.