### PR TITLE
fixes lerna npm and monorepo missteps

### DIFF
--- a/core/optionsmanager/src/handleNotFoundTryInstall.ts
+++ b/core/optionsmanager/src/handleNotFoundTryInstall.ts
@@ -2,13 +2,14 @@ import {spawnSync} from 'child_process';
 import path from 'path';
 
 function findExecPath() {
-    return process.env['$npm_execpath'] ||process.env['npm_execpath'] || require('which')
+    return process.env['$npm_execpath'] || process.env['npm_execpath'] || require('which')
         .sync('yarn', {nothrow: true}) || require('which')
         .sync('npm', {nothrow: true});
 
 }
 
 const yarnRe = /.*[/]?yarn([.]js)?$/;
+const lernaRe = /lerna[/]cli([.]js)?$/;
 /**
  * Tries to install a package as dev dependency.
  * @param e
@@ -28,6 +29,7 @@ export default function handleNotFoundTryInstall(e: Error, pkg: string, isDev = 
     if (npmPath) {
         const installPkg = `${pkg}@latest`;
         const isYarn = yarnRe.test(npmPath);
+        const isLerna = isYarn ? false : lernaRe.test(npmPath);
         if (first) {
             first = false;
             info(
@@ -47,10 +49,10 @@ export default function handleNotFoundTryInstall(e: Error, pkg: string, isDev = 
                 : 'npm'}' to install '${installPkg}'.`);
         }
 
-        const args = isYarn ? ['add', installPkg] : ['install', installPkg];
+        const args = isYarn ? ['add', installPkg] : ['add', installPkg];
 
         if (isDev) {
-            args.push(isYarn ? '-D' : '--save-dev');
+            args.push(isLerna ? '--dev' : '-D');
         }
 
         const res = spawnSync(npmPath, args, {

--- a/create-mrbuilder-monorepo/plopfile.js
+++ b/create-mrbuilder-monorepo/plopfile.js
@@ -1,8 +1,11 @@
+const {exec} = require('child_process');
 module.exports = function (plop) {
     // create your generators here
     plop.setHelper('cwd', process.cwd);
     plop.setActionType('install', function (answers) {
-        return `success\nplease run\n$ ${answers.npmClient === 'yarn' ? 'yarn install' : 'lerna bootstrap'}`;
+        return `success\nplease run
+ $ cd ${answers.namespace}     
+ $ ${answers.useYarn ? 'yarn install' : 'npm install -g lerna\n $ lerna init\n $ lerna bootstrap\n'}`;
     });
     plop.setGenerator('monorepo', {
         description: 'This is sets up a mrbuilder monorepo',
@@ -26,10 +29,10 @@ module.exports = function (plop) {
             message: 'what do you call your git origin for push?',
             default: 'origin'
         }, {
-            type: 'input',
-            name: 'npmClient',
-            message: 'which npm client would you like Lerna to use?',
-            default: 'yarn'
+            type: 'confirm',
+            name: 'useYarn',
+            message: 'use yarn?',
+            default: 'y'
         }], // array of inquirer prompts
         actions: [
             {

--- a/create-mrbuilder-monorepo/templates/builder/bin/builder.js
+++ b/create-mrbuilder-monorepo/templates/builder/bin/builder.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-process.env.MRBUILDER_PRESETS='@{{namespace}}/builder'
+process.env.MRBUILDER_PRESETS=`${__dirname}/../`
 require('@mrbuilder/cli/bin/mrbuilder');

--- a/create-mrbuilder-monorepo/templates/builder/package.json
+++ b/create-mrbuilder-monorepo/templates/builder/package.json
@@ -2,9 +2,11 @@
   "name": "@{{namespace}}/builder",
   "version": "{{version}}",
   "dependencies": {
-    "@mrbuilder/preset-lib": "^4.0.0",
-    "@mrbuilder/preset-app": "^4.0.0",
-    "@mrbuilder/cli": "^4.0.0",
+    "@mrbuilder/preset-lib": "^4.0.11",
+    "@mrbuilder/preset-app": "^4.0.11",
+    "@mrbuilder/cli": "^4.0.11",
+    "@mrbuilder/plugin-babel-7": "^4.0.10",
+    "@mrbuilder/plugin-babel": "^4.0.1",
     "@mrbuilder/plugin-typescript": "^4.0.0"
   },
   "bin": {

--- a/create-mrbuilder-monorepo/templates/lerna.json
+++ b/create-mrbuilder-monorepo/templates/lerna.json
@@ -1,10 +1,15 @@
 {
   "version": "{{version}}",
-  "npmClient": "{{npmClient}}",
-  "useWorkspaces": true,
+  "npmClient": "{{#if useYarn}}yarn{{else}}npm{{/if}}",
   "command": {
     "publish": {
       "gitRemote": "{{upstream}}"
     }
-  }
+  },
+  {{#if useYarn}}"useWorkspaces": true{{else}}"packages":[
+"{{packages}}/*",
+"./builder"
+],
+"hoist":true
+{{/if}}
 }

--- a/create-mrbuilder-monorepo/templates/package.json
+++ b/create-mrbuilder-monorepo/templates/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@{{namespace}}/project",
   "private": true,
+{{#if useYarn}}
   "workspaces": [
     "./{{packages}}/*",
     "builder"
-  ],
+  ],{{else}}
+  "scripts":{
+        "lerna":"lerna",
+        "bootstrap":"lerna bootstrap --hoist"
+},
+{{/if}}
   "dependencies": {
-    "lerna": "^3.20.2"
   }
 }

--- a/create-mrbuilder-monorepo/templates/packages/example/src/index.tsx
+++ b/create-mrbuilder-monorepo/templates/packages/example/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
 
 export default function () {
-    return <div>Hello from example</div>
+    return <div>Hello from @{{namespace}}/example</div>
 }


### PR DESCRIPTION
* So lerna's behaviour has changed a bit.  So need to check if its the running npm_execpath.  Why they didn't make it compatible with npm or yarn... I can not say.

* Discovered while trying to make the monorepo generator work with both npm and yarn.  yarn is so good, I do not know why anyone would use anything else, but to each their own.  If we hoist the lerna things mostly work