### PR TITLE
fix(webpack): initialize all of webpack up front so plugins 

### DIFF
--- a/plugins/plugin-webpack/package.json
+++ b/plugins/plugin-webpack/package.json
@@ -32,6 +32,7 @@
     "@mrbuilder/cli": "^4.0.0"
   },
   "mrbuilder": {
+    "plugin": false,
     "options": {
       "library": true,
       "libraryTarget": "umd",

--- a/plugins/plugin-webpack/src/initialConfig.ts
+++ b/plugins/plugin-webpack/src/initialConfig.ts
@@ -24,7 +24,7 @@ const returnMode = (val = process.env.NODE_ENV) => {
 
 };
 
-const mod = function ({
+export function initialConfig({
                           library,
                           libraryTarget = 'umd',
                           extensions,
@@ -184,4 +184,3 @@ const mod = function ({
 
 };
 
-module.exports = mod;


### PR DESCRIPTION
So previously the webpack plugin would configure some of itself depending on where it was required.  Making it difficult and error prone for plugins to muck with the configuration.  This change isn't really a breaking change, but should make configuration easier.

This has been changed so it only gets setup front.   This should ensure that it doesn't matter where webpack is in the stack when it is called.