### PR TITLE
fix(storybook): remove storybook css if plugin-css is enabled

### DIFF
--- a/plugins/plugin-storybook/src/register.js
+++ b/plugins/plugin-storybook/src/register.js
@@ -1,91 +1,95 @@
-
-const {enhancedResolve, asArray, logObject} = require("@mrbuilder/utils");
-const {optionsManager, Info,dotExtensions} = require('@mrbuilder/cli');
-const {resolveWebpack} = require('@mrbuilder/plugin-webpack/resolveWebpack');
+const { enhancedResolve, asArray, logObject } = require('@mrbuilder/utils');
+const { optionsManager, Info, dotExtensions } = require('@mrbuilder/cli');
+const { resolveWebpack } = require('@mrbuilder/plugin-webpack/resolveWebpack');
 
 
 const logger = optionsManager.logger('@mrbuilder/plugin-storybook');
 const tryResolve = (file) => {
-    try {
-        optionsManager.require.resolve(file);
-        return true;
-    } catch (e) {
-        return false;
-    }
-}
+  try {
+    optionsManager.require.resolve(file);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const testIf = (v, value) => v.test  ? v.test.test ? v.test.test(value) : v.test(value) : false;
 
 const removeIf = (arr, fn) => {
-    const idx = arr.findIndex(fn);
-    if (idx > -1) {
-        arr.splice(idx, 1);
-    }
-    return arr;
-}
+  const idx = arr.findIndex(fn);
+  if (idx > -1) {
+    arr.splice(idx, 1);
+  }
+  return arr;
+};
 
 async function webpackFinal(config) {
-    logger.debug('webpackFinal init');
-    logObject('from storybook', Info.isDebug, config);
-    const {entry: {...entry}, mode, devServer, output: {...output}} = config;
+  logger.debug('webpackFinal init');
+  logObject('from storybook', Info.isDebug, config);
+  const { entry: { ...entry }, mode, devServer, output: { ...output } } = config;
 
 
-    //So storybook has its own client side markdown thing.   if we are using mrbuilders, we will
-    // remove it so that we can get generated markdown instead.
-    if (optionsManager.enabled('@mrbuilder/plugin-markdown')) {
-        optionsManager.debug('disabling storybook\'s markdown using our own');
-        removeIf(config.module.rules, ({test, use: [raw] = []}) => (test && raw && test.source === '\\.md$' && /raw-loader/.test(raw.loader)));
-    }
-    if (optionsManager.enabled('@mrbuilder/plugin-babel')) {
-        optionsManager.debug('disabling storybook\'s babel using our own');
-        const oneOf = [];
-        config.module.rules = config.module.rules.filter(v => {
-            if (v.test && v.test.test && v.test.test('test.jsx')) {
-                oneOf.push(v);
-                return false;
-            }
-            return true;
-        })
-        config.module.rules.push({oneOf});
-    }
-    const webpack = await resolveWebpack(config, {isLibrary: false});
-
-    webpack.entry = entry;
-    webpack.output = output;
-    webpack.mode = mode;
-    webpack.resolve.extensions = dotExtensions;
-    //webpack.devServer = devServer;
-    delete webpack.externals;
-    webpack.module.rules.unshift({
-        test: require.resolve('./parameters.js'),
-        use: [{
-            loader: 'val-loader',
-            options: optionsManager.config('@mrbuilder/plugin-storybook.parameters', {})
-        }]
+  //So storybook has its own client side markdown thing.   if we are using mrbuilders, we will
+  // remove it so that we can get generated markdown instead.
+  if (optionsManager.enabled('@mrbuilder/plugin-markdown')) {
+    optionsManager.debug('disabling storybook\'s markdown using our own');
+    removeIf(config.module.rules, ({ test, use: [raw] = [] }) => (test && raw && test.source === '\\.md$' && /raw-loader/.test(raw.loader)));
+  }
+  if (optionsManager.enabled('@mrbuilder/plugin-babel')) {
+    optionsManager.debug('disabling storybook\'s babel using our own');
+    const oneOf = [];
+    config.module.rules = config.module.rules.filter(v => {
+      if (testIf(v, 'test.jsx')) {
+        oneOf.push(v);
+        return false;
+      }
+      return true;
     });
+    config.module.rules.push({ oneOf });
+  }
+  if (optionsManager.enabled('@mrbuilder/plugin-css')) {
+    config.module.rules = config.module.rules.filter(v => !testIf(v, 'hello.css'));
+  }
+  const webpack = await resolveWebpack(config, { isLibrary: false });
 
-    logger.debug('webpackFinal init ends');
+  webpack.entry = entry;
+  webpack.output = output;
+  webpack.mode = mode;
+  webpack.resolve.extensions = dotExtensions;
+  //webpack.devServer = devServer;
+  delete webpack.externals;
+  webpack.module.rules.unshift({
+    test: require.resolve('./parameters.js'),
+    use: [{
+      loader: 'val-loader',
+      options: optionsManager.config('@mrbuilder/plugin-storybook.parameters', {}),
+    }],
+  });
 
-    return webpack;
+  logger.debug('webpackFinal init ends');
+
+  return webpack;
 }
 
 
 const addons = [
-    ...(optionsManager.config('@mrbuilder/plugin-storybook.addons', []) || [])
-        .map(v => enhancedResolve(v, optionsManager.require))
+  ...(optionsManager.config('@mrbuilder/plugin-storybook.addons', []) || [])
+    .map(v => enhancedResolve(v, optionsManager.require)),
 ];
 
 const customAddons = optionsManager.cwd('.storybook', 'addons.js');
 if (tryResolve(customAddons)) {
-    addons.push(customAddons);
+  addons.push(customAddons);
 }
 
 const stories = [
-    ...asArray(optionsManager.config('@mrbuilder/plugin-storybook.stories', []))
-        .filter(Boolean).map(v => optionsManager.cwd(v))
-]
+  ...asArray(optionsManager.config('@mrbuilder/plugin-storybook.stories', []))
+    .filter(Boolean).map(v => optionsManager.cwd(v)),
+];
 const register = {
-    entries: [require.resolve('./stories.js')],
-    webpackFinal,
-    addons,
-    stories
+  entries: [require.resolve('./stories.js')],
+  webpackFinal,
+  addons,
+  stories,
 };
 module.exports = register;


### PR DESCRIPTION
This has been a thorn for a while.
I dunno what the correct answer is.  For now I am doing this.  I may add a custom flag to storybook in the future to maintain this behaviour.