### PR TITLE
fix: improves error reporting

### DIFF
--- a/core/optionsmanager/src/OptionsManager.ts
+++ b/core/optionsmanager/src/OptionsManager.ts
@@ -57,8 +57,10 @@ const nameConfig = (v: string | PluginNameConfig): PluginNameConfig => typeof v 
 type ResolvedOption = false | OptionType;
 
 /**
- * So checks if the message is the message for the expected
- * module, if it is bit jbiwb than returns true
+ * It checks if the message is the message for the expected module.
+ * 
+ * If it is the correct module or no module it returns false.
+ * if it is an incorrect module it returns true.
  * @param key 
  * @param message 
  * @returns 
@@ -69,7 +71,7 @@ function isIncorrectModule(key:string, message:string):boolean {
     if (!re){
         return false;
     }
-    return !re[1]?.startsWith(key);
+    return !re[1]?.includes(key);
 }
 export default class OptionsManager implements OptionsManagerType {
 

--- a/core/optionsmanager/src/OptionsManager.ts
+++ b/core/optionsmanager/src/OptionsManager.ts
@@ -66,7 +66,10 @@ type ResolvedOption = false | OptionType;
 function isIncorrectModule(key:string, message:string):boolean {
     //message 'Cannot find module '@mrbuilder/plugin-webpack''
     const re = /Cannot find module '(.+?)'/.exec(message);
-    return re?.[1] !== key;
+    if (!re){
+        return false;
+    }
+    return !re[1]?.startsWith(key);
 }
 export default class OptionsManager implements OptionsManagerType {
 

--- a/core/optionsmanager/src/OptionsManager.ts
+++ b/core/optionsmanager/src/OptionsManager.ts
@@ -56,6 +56,18 @@ const nameConfig = (v: string | PluginNameConfig): PluginNameConfig => typeof v 
 
 type ResolvedOption = false | OptionType;
 
+/**
+ * So checks if the message is the message for the expected
+ * module, if it is bit jbiwb than returns true
+ * @param key 
+ * @param message 
+ * @returns 
+ */
+function isIncorrectModule(key:string, message:string):boolean {
+    //message 'Cannot find module '@mrbuilder/plugin-webpack''
+    const re = /Cannot find module '(.+?)'/.exec(message);
+    return re?.[1] !== key;
+}
 export default class OptionsManager implements OptionsManagerType {
 
     readonly plugins = new Map<string, ResolvedOption>();
@@ -454,15 +466,17 @@ export default class OptionsManager implements OptionsManagerType {
                 continue;
             }
             let plugin: Function;
+            const pluginName = Array.isArray(option.plugin) ? option.plugin[0] : option.plugin || key;
             try {
-                plugin = this.require(Array.isArray(option.plugin) ? option.plugin[0] : option.plugin || key);
+                plugin = this.require(pluginName);
                 this.debug(key, 'found plugin');
 
             } catch (e) {
-                if (e.code !== 'MODULE_NOT_FOUND') {
+                if (e.code !== 'MODULE_NOT_FOUND' || isIncorrectModule(pluginName, e.message)) {
                     throw e;
                 }
                 this.warn(key, `was not found from '${option && option.plugin}'`);
+                this.debug(e);
                 worker(1);
                 continue;
             }


### PR DESCRIPTION
So its ok if mrbuilder can't load a plugin, some plugins aren't loadable.   Its not ok if a transient dep is not loaded.   This change checks to see if the error message is transient module missing or the requested module missing.


Either way in debug it prints out the error.