### PR TITLE
fix: removed in-publish fixes issue where mrbuilder exists 

### DIFF
--- a/core/cli/bin/mrbuilder.js
+++ b/core/cli/bin/mrbuilder.js
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 //for better yarn/npm compatibility.
 
-if (require('in-publish').inInstall()) {
-    process.exit(0);
-}
 const profileRe = /^(?:.*\/)?mrbuilder-([^/]+?)(?:\.js)?$/;
 const {env, argv} = process;
 const profile = env.MRBUILDER_PROFILE || ((idx) => {

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -4,7 +4,6 @@
   "description": "Tools for developing with mrbuilder",
   "dependencies": {
     "@mrbuilder/optionsmanager": "^4.4.6",
-    "in-publish": "^2.0.1",
     "npmlog": "^4.1.2"
   },
   "main": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12616,7 +12616,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-in-publish@^2.0.0, in-publish@^2.0.1:
+in-publish@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz#948b1a535c8030561cea522f73f78f4be357e00c"
   integrity sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==


### PR DESCRIPTION
This was added many versions ago to make npm/yarn more similar in the publishing, now that they are and in-publish is no longer necessary.