### PR TITLE
fix: removed publish config from lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,5 @@
 {
   "version": "4.4.6",
   "npmClient": "yarn",
-  "useWorkspaces": true,
-  "command": {
-    "publish": {
-      "gitRemote": "upstream",
-      "registry": "https://registry.npmjs.org"
-    }
-  }
+  "useWorkspaces": true
 }


### PR DESCRIPTION
all publish will happen from CI, don't need to have upstream push for triangle merges and publishes to work correctly.